### PR TITLE
fix: add setTimeout to sync animations

### DIFF
--- a/src/app/projects/projects.component.ts
+++ b/src/app/projects/projects.component.ts
@@ -48,7 +48,9 @@ export class ProjectsComponent implements OnInit {
 
   onProjectCreated(project: Project) {
     this.createNew = false
-    this.projects.unshift(project)
+    setTimeout(() => {
+      this.projects.unshift(project)
+    }, 300)
   }
 
   onItemDone(event: AnimationEvent, prevId: number) {


### PR DESCRIPTION
No longer janky when a new item is added to the list. The 300ms for the setTimeout is the same as the '300ms ease-out' timing for the 'slidUp => slidDown' animation.